### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/daf6ae1c-57b7-441e-98f1-e4adc0640603/46cac2e6-82e0-4184-a9f5-ccf99cf25437/_apis/work/boardbadge/3eee3b96-8f15-4597-b452-bfab48bedae9)](https://dev.azure.com/aiw-devops/daf6ae1c-57b7-441e-98f1-e4adc0640603/_boards/board/t/46cac2e6-82e0-4184-a9f5-ccf99cf25437/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#954. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.